### PR TITLE
Avoid second array allocation in matrix multiplication

### DIFF
--- a/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/GeneticNeuralNetwork.java
+++ b/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/GeneticNeuralNetwork.java
@@ -18,6 +18,10 @@ public class GeneticNeuralNetwork extends NeuralNetwork {
 
     private double mutationRate;
 
+    private final Matrix[] weightMutationRates;
+    private final Matrix[] biasMutationRates;
+
+
     private final Random random = new Random();
 
     /**
@@ -34,6 +38,18 @@ public class GeneticNeuralNetwork extends NeuralNetwork {
                                 int... hiddenNodes) {
         super(learningRate, inputNodes, outputNodes, hiddenNodes);
         this.mutationRate = mutationRate;
+        this.weightMutationRates = new Matrix[this.weights.length];
+        for (int i = 0; i < weights.length; i++) {
+            Matrix mutationRates = new Matrix(weights[i].getRows(), weights[i].getColumns())
+                    .fill(mutationRate);
+            this.weightMutationRates[i] = mutationRates;
+        }
+        this.biasMutationRates = new Matrix[this.biases.length];
+        for (int i = 0; i < biases.length; i++) {
+            Matrix mutationRates = new Matrix(weights[i].getRows(), weights[i].getColumns())
+                    .fill(mutationRate);
+            this.biasMutationRates[i] = mutationRates;
+        }
     }
 
     /**
@@ -54,13 +70,7 @@ public class GeneticNeuralNetwork extends NeuralNetwork {
      * @return this, after mutation
      */
     public GeneticNeuralNetwork mutate(double mutationRate) {
-        for (Matrix weight : this.weights) {
-            weight.map((d, r, c) -> random.nextDouble() < mutationRate ? random.nextDouble() - 0.5 : d);
-        }
-        for (Matrix bias : this.biases) {
-            bias.map((d, r, c) -> random.nextDouble() < mutationRate ? random.nextDouble() - 0.5 : d);
-        }
-        return this;
+        return mutate(mutationRate, Mutators.uniform(), Mutators.uniform());
     }
 
     /**
@@ -74,11 +84,31 @@ public class GeneticNeuralNetwork extends NeuralNetwork {
      * @return this, after mutation
      */
     public GeneticNeuralNetwork mutate(double mutationRate, Mutator weightMutator, Mutator biasMutator) {
-        for (Matrix weight : this.weights) {
-            weight.map((d, r, c) -> random.nextDouble() < mutationRate ? weightMutator.mutate(mutationRate, d, r, c) : d);
+        for (int i = 0; i < this.weights.length; i++) {
+            Matrix weight = this.weights[i];
+            final int finalI = i;
+            weight.map((d, r, c) -> {
+                double oldMutationRate = this.weightMutationRates[finalI].get(r, c);
+
+                double z = random.nextGaussian();
+                double newMutationRate = oldMutationRate * Math.exp(z);
+                this.weightMutationRates[finalI].set(r, c, newMutationRate);
+
+                return random.nextDouble() < mutationRate ? weightMutator.mutate(random, newMutationRate, d, r, c) : d;
+            });
         }
-        for (Matrix bias : this.biases) {
-            bias.map((d, r, c) -> random.nextDouble() < mutationRate ? biasMutator.mutate(mutationRate, d, r, c) : d);
+        for (int i = 0; i < this.biases.length; i++) {
+            Matrix bias = this.biases[i];
+            final int finalI = i;
+            bias.map((d, r, c) -> {
+                double oldMutationRate = this.biasMutationRates[finalI].get(r, c);
+
+                double z = random.nextGaussian();
+                double newMutationRate = oldMutationRate * Math.exp(z);
+                this.biasMutationRates[finalI].set(r, c, newMutationRate);
+
+                return random.nextDouble() < mutationRate ? biasMutator.mutate(random, newMutationRate, d, r, c) : d;
+            });
         }
         return this;
     }

--- a/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/GeneticNeuralNetwork.java
+++ b/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/GeneticNeuralNetwork.java
@@ -64,6 +64,26 @@ public class GeneticNeuralNetwork extends NeuralNetwork {
     }
 
     /**
+     * A portion (mutation rate) of the weights in the network are randomly reassigned through a mutation of the neural network.
+     * <p>
+     * This function modifies the calling neural network object. This means that the return value of this function does not necessarily have to be used.
+     *
+     * @param mutationRate  The rate of mutation. The higher the rate, the more weights are mutated.
+     * @param weightMutator The mutator to use for mutation of weights. This allows for custom mutation strategies.
+     * @param biasMutator   The mutator to use for mutation of biases. This allows for custom mutation strategies.
+     * @return this, after mutation
+     */
+    public GeneticNeuralNetwork mutate(double mutationRate, Mutator weightMutator, Mutator biasMutator) {
+        for (Matrix weight : this.weights) {
+            weight.map((d, r, c) -> random.nextDouble() < mutationRate ? weightMutator.mutate(mutationRate, d, r, c) : d);
+        }
+        for (Matrix bias : this.biases) {
+            bias.map((d, r, c) -> random.nextDouble() < mutationRate ? biasMutator.mutate(mutationRate, d, r, c) : d);
+        }
+        return this;
+    }
+
+    /**
      * Via crossover of two neural networks, a random mix of these two networks is created, as in real DNA.
      *
      * @param other The other neural network to crossover with.

--- a/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/Mutator.java
+++ b/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/Mutator.java
@@ -1,0 +1,19 @@
+package org.schlunzis.zis.ai.nn;
+
+@FunctionalInterface
+public interface Mutator {
+
+    /**
+     * Mutates the value using the given mutation rate.
+     * <p>
+     * Implementations must make sure that the returned value is between -0.5 and 0.5.
+     *
+     * @param oldValue     the value to mutate
+     * @param mutationRate the mutation rate
+     * @param row          the row of the value in the weight or bias matrix
+     * @param col          the column of the value in the weight or bias matrix
+     * @return the new value after mutation
+     */
+    double mutate(double mutationRate, double oldValue, int row, int col);
+
+}

--- a/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/Mutator.java
+++ b/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/Mutator.java
@@ -1,19 +1,20 @@
 package org.schlunzis.zis.ai.nn;
 
+import java.util.Random;
+
 @FunctionalInterface
 public interface Mutator {
 
     /**
      * Mutates the value using the given mutation rate.
-     * <p>
-     * Implementations must make sure that the returned value is between -0.5 and 0.5.
      *
-     * @param oldValue     the value to mutate
+     * @param random       the random instance to use for mutation
      * @param mutationRate the mutation rate
+     * @param oldValue     the value to mutate
      * @param row          the row of the value in the weight or bias matrix
      * @param col          the column of the value in the weight or bias matrix
      * @return the new value after mutation
      */
-    double mutate(double mutationRate, double oldValue, int row, int col);
+    double mutate(Random random, double mutationRate, double oldValue, int row, int col);
 
 }

--- a/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/Mutators.java
+++ b/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/Mutators.java
@@ -1,12 +1,14 @@
 package org.schlunzis.zis.ai.nn;
 
-import java.util.concurrent.ThreadLocalRandom;
-
 public class Mutators {
 
-    private static final Mutator GAUSSIAN = (mutationRate, oldValue, r, c) -> {
-        double z = ThreadLocalRandom.current().nextGaussian();
+    private static final Mutator GAUSSIAN = (random, mutationRate, oldValue, r, c) -> {
+        double z = random.nextGaussian();
         return oldValue + z * mutationRate;
+    };
+
+    private static final Mutator UNIFORM = (random, mutationRate, oldValue, r, c) -> {
+        return random.nextDouble() < mutationRate ? random.nextDouble() - 0.5 : oldValue;
     };
 
     private Mutators() {
@@ -19,6 +21,15 @@ public class Mutators {
      */
     public static Mutator gaussian() {
         return GAUSSIAN;
+    }
+
+    /**
+     * A mutator which mutates each value based on a uniform distribution between -0.5 and 0.5
+     *
+     * @return the uniform mutator
+     */
+    public static Mutator uniform() {
+        return UNIFORM;
     }
 
 }

--- a/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/Mutators.java
+++ b/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/Mutators.java
@@ -1,0 +1,24 @@
+package org.schlunzis.zis.ai.nn;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class Mutators {
+
+    private static final Mutator GAUSSIAN = (mutationRate, oldValue, r, c) -> {
+        double z = ThreadLocalRandom.current().nextGaussian();
+        return oldValue + z * mutationRate;
+    };
+
+    private Mutators() {
+    }
+
+    /**
+     * A mutator which mutates each value based on a Gaussian distribution.
+     *
+     * @return the Gaussian mutator
+     */
+    public static Mutator gaussian() {
+        return GAUSSIAN;
+    }
+
+}

--- a/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/NeuralNetwork.java
+++ b/zis-ai/src/main/java/org/schlunzis/zis/ai/nn/NeuralNetwork.java
@@ -197,7 +197,7 @@ public class NeuralNetwork implements Serializable {
      */
     public Matrix query(Matrix inputs_list) {
 
-        Matrix matrix = Matrix.transpose(inputs_list);
+        Matrix matrix = inputs_list;
         for (int i = 0; i < weights.length; i++) {
             matrix = Matrix.matmul(weights[i], matrix);
             matrix.add(biases[i]);
@@ -227,14 +227,14 @@ public class NeuralNetwork implements Serializable {
     public void train(Matrix inputs_list, Matrix targets_list) {
 
         Matrix[] results = new Matrix[weights.length + 1];
-        results[0] = Matrix.transpose(inputs_list);
+        results[0] = inputs_list.copy();
         for (int i = 0; i < weights.length; i++) {
             results[i + 1] = Matrix.matmul(weights[i], results[i]);
             results[i + 1].add(biases[i]);
             results[i + 1].map((d, r, c) -> actFunc.activate(d));
         }
 
-        Matrix error = Matrix.sub(Matrix.transpose(targets_list), results[results.length - 1]);
+        Matrix error = Matrix.sub(targets_list, results[results.length - 1]);
         Matrix gradients = results[results.length - 1].map((d, r, c) -> actFunc.deactivate(d));
         gradients.hadamard(error);
         gradients.mult(learningRate);

--- a/zis-ai/src/test/java/org/schlunzis/zis/ai/nn/NeuralNetworkTest.java
+++ b/zis-ai/src/test/java/org/schlunzis/zis/ai/nn/NeuralNetworkTest.java
@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class NeuralNetworkTest {
 
     final Matrix[][] xOrData = new Matrix[][]{{
-            new Matrix(new double[][]{{0, 0}}), new Matrix(new double[][]{{0}})},
-            {new Matrix(new double[][]{{0, 1}}), new Matrix(new double[][]{{1}})},
-            {new Matrix(new double[][]{{1, 0}}), new Matrix(new double[][]{{1}})},
-            {new Matrix(new double[][]{{1, 1}}), new Matrix(new double[][]{{0}})
+            new Matrix(new double[][]{{0}, {0}}), new Matrix(new double[][]{{0}})},
+            {new Matrix(new double[][]{{0}, {1}}), new Matrix(new double[][]{{1}})},
+            {new Matrix(new double[][]{{1}, {0}}), new Matrix(new double[][]{{1}})},
+            {new Matrix(new double[][]{{1}, {1}}), new Matrix(new double[][]{{0}})
             }};
 
     @Test
@@ -36,7 +36,7 @@ class NeuralNetworkTest {
             Matrix input = xOrDatum[0];
             double predicted = nn.query(input).get(0, 0);
             double expected = xOrDatum[1].get(0, 0);
-            assertTrue(Math.abs(expected - predicted) < 0.2, "Input: " + input.get(0, 0) + ", " + input.get(0, 1) +
+            assertTrue(Math.abs(expected - predicted) < 0.2, "Input: " + input.get(0, 0) + ", " + input.get(1, 0) +
                     " | Expected: " + expected + " | Predicted: " + predicted);
         }
     }
@@ -48,7 +48,7 @@ class NeuralNetworkTest {
             Matrix input = xOrDatum[0];
             double predicted = nn.query(input).get(0, 0);
             double expected = xOrDatum[1].get(0, 0);
-            assertTrue(Math.abs(expected - predicted) < 0.2, "Input: " + input.get(0, 0) + ", " + input.get(0, 1) +
+            assertTrue(Math.abs(expected - predicted) < 0.2, "Input: " + input.get(0, 0) + ", " + input.get(1, 0) +
                     " | Expected: " + expected + " | Predicted: " + predicted);
         }
     }

--- a/zis-math/src/main/java/org/schlunzis/zis/math/linear/Matrix.java
+++ b/zis-math/src/main/java/org/schlunzis/zis/math/linear/Matrix.java
@@ -63,13 +63,14 @@ public class Matrix implements Serializable {
         if (a.getColumns() != b.getRows())
             throw new IllegalArgumentException("A's cols and B's rows must match!");
 
-        double[][] newData = new double[a.getRows()][b.getColumns()];
+        Matrix newMatrix = new Matrix(a.getRows(), b.getColumns());
+        double[][] newData = newMatrix.data;
         for (int row = 0; row < a.getRows(); row++)
             for (int col = 0; col < b.getColumns(); col++)
                 for (int j = 0; j < a.getColumns(); j++)
                     newData[row][col] += a.data[row][j] * b.data[j][col];
 
-        return new Matrix(newData);
+        return newMatrix;
     }
 
     /**


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Optimization

## Description

Reduce allocations in matrix multiplications.



